### PR TITLE
Fix detached HEAD issue in create-release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -21,6 +21,7 @@ jobs:
       with:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
+        ref: main
 
     - name: Determine version
       id: version
@@ -99,7 +100,7 @@ jobs:
           echo "No changes to commit"
         else
           git commit -m "Release v${{ steps.version.outputs.version }} - $(date +'%Y-%m-%d')"
-          git push
+          git push origin main
         fi
 
     - name: Create GitHub Release (on tag)


### PR DESCRIPTION
- Explicitly checkout 'main' branch to avoid detached HEAD state
- Push to 'origin main' explicitly instead of relying on current branch

This fixes the error: "You are not currently on a branch"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to ensure reliable and consistent release deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->